### PR TITLE
Use exec in entrypoint scripts

### DIFF
--- a/start_server.sh
+++ b/start_server.sh
@@ -14,8 +14,8 @@ if [ $DJANGO_ENV == "production" ]; then
     python manage.py collectstatic
   fi
   echo Starting production server
-  gunicorn theia.wsgi -b 0:8080
+  exec gunicorn theia.wsgi -b 0:8080
 else
   echo Starting development server
-  python manage.py runserver 0:8080
+  exec python manage.py runserver 0:8080
 fi

--- a/start_worker.sh
+++ b/start_worker.sh
@@ -4,5 +4,4 @@ echo Removing logs
 rm tmp/*.log
 
 echo Starting Celery
-celery -A theia worker -l info
-
+exec celery -A theia worker -l info


### PR DESCRIPTION
This way the server process will receive any signals from Docker rather
than them being sent to bash (e.g. when the container shuts down).