### PR TITLE
Add models to admin.py so they will show up in the admin UI

### DIFF
--- a/theia/api/admin.py
+++ b/theia/api/admin.py
@@ -1,3 +1,12 @@
 from django.contrib import admin  # noqa: F401
 
 # Register your models here.
+
+from .models import *
+
+admin.site.register(Project)
+admin.site.register(Pipeline)
+admin.site.register(PipelineStage)
+admin.site.register(JobBundle)
+admin.site.register(RequestedScene)
+admin.site.register(ImageryRequest)

--- a/theia/api/models/imagery_request.py
+++ b/theia/api/models/imagery_request.py
@@ -12,24 +12,24 @@ class ImageryRequest(models.Model):
     dataset_name = models.CharField(max_length=64, null=False)
 
     max_cloud_cover = models.IntegerField(null=True)
-    begin_date = models.DateTimeField(null=True)
-    end_date = models.DateTimeField(null=True)
+    begin_date = models.DateTimeField(null=True, blank=True)
+    end_date = models.DateTimeField(null=True, blank=True)
 
     max_results = models.IntegerField(null=True)
 
     wgs_row = models.IntegerField(null=True)
     wgs_path = models.IntegerField(null=True)
 
-    kml_polygon = models.TextField(null=True)
-    bounding_left = models.FloatField(null=True)
-    bounding_right = models.FloatField(null=True)
-    bounding_top = models.FloatField(null=True)
-    bounding_bottom = models.FloatField(null=True)
+    kml_polygon = models.TextField(null=True, blank=True)
+    bounding_left = models.FloatField(null=True, blank=True)
+    bounding_right = models.FloatField(null=True, blank=True)
+    bounding_top = models.FloatField(null=True, blank=True)
+    bounding_bottom = models.FloatField(null=True, blank=True)
 
-    user_id = models.IntegerField(null=True)
-    status = models.IntegerField(db_index=True, default=0)
+    user_id = models.IntegerField(null=True, blank=True)
+    status = models.IntegerField(db_index=True, default=0, blank=True)
 
-    created_at = models.DateTimeField(null=False, auto_now_add=True, db_index=True)
+    created_at = models.DateTimeField(null=False, auto_now_add=True, db_index=True, blank=True)
 
     project = models.ForeignKey(Project, related_name='imagery_requests', on_delete=models.CASCADE)
     pipeline = models.ForeignKey(Pipeline, related_name='imagery_requests', on_delete=models.CASCADE)

--- a/theia/api/models/pipeline_stage.py
+++ b/theia/api/models/pipeline_stage.py
@@ -5,10 +5,10 @@ from .pipeline import Pipeline
 
 class PipelineStage(models.Model):
     sort_order = models.IntegerField(null=False)
-    output_format = models.CharField(max_length=8, null=True)
+    output_format = models.CharField(max_length=8, null=True, blank=True)
     operation = models.CharField(max_length=64, null=False)
     select_images = ArrayField(models.CharField(max_length=64, null=False), null=True)
-    config = JSONField()
+    config = JSONField(blank=True)
     pipeline = models.ForeignKey(Pipeline, related_name='pipeline_stages', on_delete=models.CASCADE)
 
     class Meta:


### PR DESCRIPTION
Theia is built on a python web framework called [Django](https://docs.djangoproject.com), which occupies approximately the role in the Python community that Rails occupies in the Ruby community. 

### A Small Map of Django for the Rails-Initiated, Part 1 

 - The info you would expect to find in the Rails 'routes.rb' file lives in a file called 'urls.py.'
 - The role of 'Controllers' in Rails is occupied by classes called 'Views' or 'ViewSets' in Django. We have one of these for each of our Models. Now there's something important to note here: _unlike_ Rails, Django does _not_ default to "restful" routes. A _normal_ Django app would have to specify, roughly, which verbs and URLs do what. Theia, however, uses `django-rest`, which defaults to restful routes. So we don't have to wire everything up manually, which is why you don't see a whole lot in these view set files.
 - The role of 'Views' in Rails is occupied by 'templates' in Django. These live in a folder called 'templates,' and they're html files with an erb-like syntax for injecting code. Theia is an API app, but we do have one view where you can see this. It's called 'home.html.'
 - Models in Django, like Models in Rails, live in a directory called "models." They all have to extend "Model" from the models package, which provides two things you should know about right away:
      1. An ActiveRecord-like python API for manipulating database objects in code, or in the console. [Here are docs on that.](https://docs.djangoproject.com/en/3.0/topics/db/queries/)
      1. Auto-generating migrations. In Django, you don't have to generate migrations to change the schema of database objects the way you do in Rails. Instead, you edit the model class, and Django generates the migration for you when you run: `$ ./manage.py makemigrations`. You can then look at the migration file, which is temporary and _not_ committed (each new instance of a Django app decides what SQL commands to run to set up the database based on the content of the model classes at the time of instantiation; the migration generated above is specifically for the purpose of updating _your_ local schema to match your models). When ready, you can migrate with `$ ./manage.py migrate`.

### Okay, now we're getting more specific to _this_ PR.

Django ships standard with a very nice thing: an admin UI. 

Once you have the app set up, navigate to the app directory and run:
`$ pipenv run createsuperuser`
and follow the instructions. This sets up your local _admin user_.

You can now go to localhost:8080/admin and log in with those admin credentials. There, you will see a UI. 

<img width="763" alt="Screen Shot 2019-12-09 at 2 03 58 PM" src="https://user-images.githubusercontent.com/5744164/70468499-d173eb00-1a8c-11ea-9636-4382eebce785.png">

The UI shows you all of our models. If you click on one, it will show you all the _instances_ of that model currently in the table. You can view, edit, and delete them individually. You can even create new ones in there. 

It's pretty sweet, but in order for the models to show up in there, we have to _register_ them in the admin.py file. That's this PR.

There's one more change in this PR: several fields specified in the Models receive an attribute called `blank=true`. This means 'when people edit this model, it is okay for them to leave this attribute blank.' You would think `null=True` would take care of this, and you'd mostly be right...except not in the admin UI. The admin UI includes some relatively rudimentary form validation that gets mad when you try to edit valid models if fields are left blank, unless they have this. You can tell in the admin UI if it's gonna get mad about this based on whether the name of the attribute is bold in the UI or not:

<img width="639" alt="Blanks_png" src="https://user-images.githubusercontent.com/5744164/70468783-53fcaa80-1a8d-11ea-8149-33847a45cd51.png">



