### PR TITLE
Adjust EROS adapter to match new integration spec

### DIFF
--- a/tests/adapters/usgs/test_eros_wrapper.py
+++ b/tests/adapters/usgs/test_eros_wrapper.py
@@ -23,7 +23,7 @@ class TestErosWrapper:
     @patch('theia.adapters.usgs.ErosWrapper.eros_post', return_value={'data': 'aaaaaa'})
     def test_successful_connect(self, mockPost, mockToken, mockPassword, mockUsername):
         result = ErosWrapper.connect()
-        mockPost.assert_called_once_with('login', {'username': 'u', 'password': 'p'})
+        mockPost.assert_called_once_with('login', {'username': 'u', 'password': 'p'}, authenticating=True)
 
     @patch('theia.adapters.usgs.ErosWrapper.token', return_value=None)
     @patch('theia.adapters.usgs.ErosWrapper.eros_post', return_value={'errorCode': 1})
@@ -84,7 +84,7 @@ class TestErosWrapper:
             result = ErosWrapper.eros_prepare({'key': 'value'}, params={'foo': 'bar'})
             assert result == {
                 'headers': {'Content-Type': 'application/json', 'X-Auth-Token': 'aaaaaa'},
-                'params': {'foo': 'bar', 'jsonRequest': '{"key": "value"}'}
+                'params': {'jsonRequest': '{"key": "value"}'}
             }
 
             result = ErosWrapper.eros_prepare({'key': 'value'}, headers={'X-Foo': 'bar'})
@@ -103,7 +103,7 @@ class TestErosWrapper:
             result = ErosWrapper.eros_post('endpoint', {'foo': 'bar'}, thing='thing')
 
             mockConnect.assert_called_once()
-            mockPrepare.assert_called_once_with({'foo': 'bar'}, thing='thing')
+            mockPrepare.assert_called_once_with({'foo': 'bar'}, authenticating=False, thing='thing')
             mockUrl.assert_called_once_with('endpoint')
             mockPost.assert_called_once_with('api_url', prepare='result')
             assert(result=='some json string')
@@ -118,13 +118,13 @@ class TestErosWrapper:
             result = ErosWrapper.eros_get('endpoint', {'foo': 'bar'}, thing='thing')
 
             mockConnect.assert_called_once()
-            mockPrepare.assert_called_once_with({'foo': 'bar'}, thing='thing')
+            mockPrepare.assert_called_once_with({'foo': 'bar'}, authenticating=False, thing='thing')
             mockUrl.assert_called_once_with('endpoint')
             mockPost.assert_called_once_with('api_url', prepare='result')
             assert(result=='some json string')
 
     def test_api_url(self):
-        assert(ErosWrapper.api_url('foo')=='https://earthexplorer.usgs.gov/inventory/json/v/stable/foo')
+        assert(ErosWrapper.api_url('foo')=='https://earthexplorer.usgs.gov/inventory/json/v/1.3.0/foo')
 
     @patch('theia.adapters.usgs.ErosWrapper.eros_post', return_value={'data': 'foo'})
     def test_search_once(self, mockPost):


### PR DESCRIPTION
Theia is designed to be a one stop shop for researchers to request images from NASA LANDSAT satellites (and someday possibly other satellites), perform manipulations on those images (like resizing, cropping, or colorizing them), and upload those to a project on panoptes to use as subject sets.

As such, theia integrates with a variety of services. One of the very first services with which it integrates is EROS.

EROS is the United States Geological Survey's API for searching for images from the LANDSAT satellites. We integrate with EROS to allow researchers to search for, and request, the images they need for their projects. This involves two steps:

1. Authenticating with EROS
2. Making the imagery requests themselves

Once upon a time, the way EROS authenticated users was by having clients stick their credentials into a JSON request object that got URL encoded and jammed onto the end of the request URL.

We suspect that, at some point, someone over at EROS saw that and told the team that it was bad practice to do that. So now, for authentication, EROS does not accept that. Instead, it expects the credentials in the body of the authentication request.

Now, for the _image search_ requests, EROS does _not_ accept the credentials in the body of the request. These requests still expect credential information jammed onto the request URL. 

So this PR changes our wrapper such that the authentication request submits credentials in the body, and the other requests submit credentials in the request URL. 

It also locks our integration to version 1.3.0 of the EROS API so that changes to the API don't break us anymore.

To test:
1. Navigate to app directory
1. `$ pipenv run console`
1. `$ from theia.tasks import locate_scenes`
1. Go into the Admin UI or the REST UI and create an imagery request. Get the ID of that imagery request.
1. `$ locate_scenes(<ImageryRequest id>)`

If the integration fails, you'll see the error from EROS in the console there. If it appears to hang for a while and then returns nothing, it worked.