### PR TITLE
Add libtiff to Pipfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update \
     gdal-bin \
     libtiff5-dev \
     libgdal-dev \
-    python-gdal \
     python3-gdal \
     binutils \
     netcat \
@@ -27,9 +26,6 @@ COPY start_server.sh ./
 COPY start_worker.sh ./
 
 RUN pipenv install --system --dev
-# for some reason pipenv can't install libtiff
-# manually install it using pip and lock the version to the known working one
-RUN pip install -Iv libtiff==0.4.2
 
 RUN export GDAL_VERSION=$(gdal-config --version) \
   && pip install --global-option=build_ext --global-option="-I/usr/include/gdal/" \

--- a/Pipfile
+++ b/Pipfile
@@ -62,6 +62,7 @@ urllib3 = "==1.24.3"
 vine = "==1.3.0"
 wcwidth = "==0.1.7"
 zipp = "==0.5.2"
+libtiff = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3194e7213f96eb2b8c01dd7c31681c08badcd78e1fe9119d4c67cfc7c5898b54"
+            "sha256": "c0353211b5bf75a3f953f415e9b42a2febd28126c06734d363150e0d3f4fb71e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -209,6 +209,13 @@
             ],
             "index": "pypi",
             "version": "==1.0"
+        },
+        "libtiff": {
+            "hashes": [
+                "sha256:8b80660541bfc51309b22dd676bcc94a8d77324b00fba3d331b7f564775f17a6"
+            ],
+            "index": "pypi",
+            "version": "==0.4.2"
         },
         "lxml": {
             "hashes": [


### PR DESCRIPTION
Also removed `python-gdal` package. You don't need that in addition to
`python3-gdal`, as `python-gdal` is the Python 2 verion and it was
pulling in the whole of Python 2 with it, which is what was screwing up
libtiff I think.