### PR TITLE
Updates for production deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,13 +27,15 @@ pipeline {
       }
     }
 
-    stage('Deploy staging to Kubernetes') {
-      when { branch 'master' }
-      agent any
-      steps {
-        sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment-staging.tmpl | kubectl --context azure apply --record -f -"
-      }
-    }
+
+    // NO STAGING DEPLOY as of Jan 2021
+    // stage('Deploy staging to Kubernetes') {
+    //   when { branch 'master' }
+    //   agent any
+    //   steps {
+    //     sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment-staging.tmpl | kubectl --context azure apply --record -f -"
+    //   }
+    // }
 
     stage('Deploy production to Kubernetes') {
       when { tag 'production-release' }

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -69,3 +69,66 @@ spec:
   resources:
     requests:
       storage: 5Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: theia-production-redis
+  labels:
+    app: theia-production-redis
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: theia-production-redis
+  template:
+    metadata:
+      labels:
+        app: theia-production-redis
+    spec:
+      tolerations:
+      - key: "servicelife"
+        operator: "Equal"
+        value: "longlife"
+        effect: "NoSchedule"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: servicelife
+                operator: In
+                values:
+                - longlife
+      containers:
+        - name: theia-production-redis
+          image: redis
+          resources:
+            requests:
+              memory: "10Mi"
+              cpu: "10m"
+            limits:
+              memory: "100Mi"
+              cpu: "500m"
+          volumeMounts:
+          - name: theia-production-redis-data
+            mountPath: "/data"
+      volumes:
+      - name: theia-production-redis-data
+        persistentVolumeClaim:
+          claimName: theia-production-redis
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: theia-production-redis
+spec:
+  selector:
+    app: theia-production-redis
+  ports:
+    - protocol: TCP
+      port: 6379
+      targetPort: 6379
+  type: NodePort

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -24,22 +24,15 @@ spec:
             limits:
               memory: "200Mi"
               cpu: "500m"
+          envFrom:
+          - secretRef:
+              name: theia-production-env-vars
           env:
-            - name: PANOPTES_URL
-              value: https://panoptes.zooniverse.org/
-            - name: PANOPTES_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: theia-production
-                  key: PANOPTES_CLIENT_ID
-            - name: PANOPTES_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: theia-production
-                  key: PANOPTES_CLIENT_SECRET
-            volumeMounts:
-              - name: theia-production-volume
-                mountPath: "/tmp"
+          - name: PANOPTES_PROD_URL
+            value: https://panoptes.zooniverse.org/
+          volumeMounts:
+            - name: theia-production-volume
+              mountPath: "/tmp"
       volumes:
         - name: theia-production-volume
           persistentVolumeClaim:

--- a/theia/settings.py
+++ b/theia/settings.py
@@ -84,14 +84,14 @@ WSGI_APPLICATION = 'theia.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
-if os.environ.get('ENV') == "staging":
+if os.environ.get('ENV') == "production":
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
-            'NAME': 'theia_staging',
-            'USER': os.getenv('STAGING_DB_USERNAME'),
-            'PASSWORD': os.getenv('STAGING_DB_PASSWORD'),
-            'HOST': os.getenv('STAGING_DB_HOST'),
+            'NAME': 'theia_production',
+            'USER': os.getenv('PRODUCTION_DB_USERNAME'),
+            'PASSWORD': os.getenv('PRODUCTION_DB_PASSWORD'),
+            'HOST': os.getenv('PRODUCTION_DB_HOST'),
             'PORT': 5432
         }
     }


### PR DESCRIPTION
* Add the redis deployment to production
* load the production secret full of env vars w/ secretRef
* update settings.py to check `os.get('ENV')` for production instead of staging, as there will be no staging deploy for this app (for now).
* For the same reason, comment out the staging deploy in the Jenkinsfile. Production deploys can still use chatops to update the tag.
* Created a new production db and a new production k8s secret with its credentials as well as those of Theia's Panoptes Doorkeeper app.

Should be good to go once the DNS updates are merged in the ops repo.