### PR TITLE
Deployment touchups

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: theia-production-app
-          image: zooniverse/theia:__IMAGE_TAG__
+          image: zooniverse/theia:latest
           resources:
             requests:
               memory: "200Mi"
@@ -112,6 +112,18 @@ spec:
       - name: theia-production-redis-data
         persistentVolumeClaim:
           claimName: theia-production-redis
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: theia-production-redis
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: azurefile
+  resources:
+    requests:
+      storage: 5Gi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -30,6 +30,8 @@ spec:
           env:
           - name: PANOPTES_PROD_URL
             value: https://panoptes.zooniverse.org/
+          - name: ENV
+            value: production
           volumeMounts:
             - name: theia-production-volume
               mountPath: "/tmp"

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: theia-production-app
-          image: zooniverse/theia:latest
+          image: zooniverse/theia:__IMAGE_TAG__
           resources:
             requests:
               memory: "200Mi"

--- a/start_server.sh
+++ b/start_server.sh
@@ -8,7 +8,7 @@ done
 echo Applying migrations
 python manage.py migrate --noinput
 
-if [ "$DJANGO_ENV" == "production" ]; then
+if [ "$ENV" == "production" ]; then
   if [ ! -d "theia/static" ]; then
     echo Generating static files
     python manage.py collectstatic

--- a/theia/settings.py
+++ b/theia/settings.py
@@ -19,7 +19,10 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '6n$fr-9vudyln(o=6jzv*pr_3b9(kajv=#&wq6ep4vm_s1m@6p'
+if os.environ.get('ENV') == "production":
+    SECRET_KEY = os.environ.get('SECRET_KEY')
+else
+    SECRET_KEY = '6n$fr-9vudyln(o=6jzv*pr_3b9(kajv=#&wq6ep4vm_s1m@6p'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
* Redis needs a persistent volume claim
* Add the `ENV` env var so Django needs to know where it is.
* Update server starter to use above
* Load the secret key (generated by me via Django console and set in k8s secret as env var) from env var in settings for production