### PR TITLE
For OAuth to work, the container needs some additional environment variables.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,12 @@
 export USGS_USERNAME=something_secret_goes_here
 export USGS_PASSWORD=something_secret_goes_here
 
-export PANOPTES_PROD_CLIENT_ID=something_secret_goes_here
-export PANOPTES_PROD_CLIENT_SECRET=something_secret_goes_here
-export PANOPTES_PROD_URL=https://panoptes.zooniverse.org/
-
-export PANOPTES_STAGING_CLIENT_ID=something_secret_goes_here
-export PANOPTES_STAGING_CLIENT_SECRET=something_secret_goes_here
-export PANOPTES_STAGING_URL=https://panoptes-staging.zooniverse.org/
-
 export STAGING_DB_USERNAME=example_username
 export STAGING_DB_PASSWORD=example_password
-export STAGING_DB_PASSWORD=hostname.example.com
+
+PANOPTES_CLIENT_ID=some_key
+PANOPTES_CLIENT_SECRET=some_key
+PANOPTES_URL=https://panoptes.zooniverse.org/
+
+PANOPTES_PROD_USERNAME=a_username
+PANOPTES_PROD_USER_KEY=a_user_key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,11 @@ services:
       - STAGING_DB_USERNAME
       - STAGING_DB_PASSWORD
       - STAGING_DB_HOST
+      - PANOPTES_CLIENT_ID
+      - PANOPTES_CLIENT_SECRET
+      - PANOPTES_URL
+      - PANOPTES_PROD_USERNAME
+      - PANOPTES_PROD_USER_KEY
     ports:
       - "8080:8080"
     links:

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -28,7 +28,7 @@ spec:
           - secretRef:
               name: theia-production-env-vars
           env:
-          - name: PANOPTES_PROD_URL
+          - name: PANOPTES_URL
             value: https://panoptes.zooniverse.org/
           - name: ENV
             value: production


### PR DESCRIPTION
I have included them here in `docker-compose` file.

@zwolf if you need I can find a way to get the values for these env vars to ya!

Now, this doesn't _fully_ fix oauth, because now when I go to authenticate I get "the redirect_uri is invalid." I've fixed this issue once before with @camallen, and the solution had to do with doorkeeper wanting a backslash. So I went into our oauth app for theia: https://panoptes.zooniverse.org/oauth/applications/128 and added the appropriate (I THOUGHT) redirect uri for our prod deployment, and I'm still getting the same error. 

Does anything look wrong with that redirect_uri I added?