### PR TITLE
Hopefully get theia authenticating over https in prod

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -29,7 +29,7 @@ spec:
               name: theia-production-env-vars
           env:
           - name: PANOPTES_URL
-            value: https://panoptes.zooniverse.org/
+            value: https://www.zooniverse.org/
           - name: ENV
             value: production
           - name: DJANGO_ALLOWED_HOSTS

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -30,7 +30,7 @@ spec:
           env:
           - name: PANOPTES_URL
             value: https://www.zooniverse.org/
-          - name: ENV
+          - name: NAME
             value: production
           - name: DJANGO_ALLOWED_HOSTS
             value: theia.zooniverse.org

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -27,7 +27,7 @@ spec:
           env:
             - name: PANOPTES_URL
               value: https://panoptes-staging.zooniverse.org/
-            - name: ENV
+            - name: NAME
               value: staging
             - name: PANOPTES_CLIENT_ID
               valueFrom:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -27,6 +27,8 @@ spec:
           env:
             - name: PANOPTES_URL
               value: https://panoptes-staging.zooniverse.org/
+            - name: ENV
+              value: staging
             - name: PANOPTES_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/theia/settings.py
+++ b/theia/settings.py
@@ -25,7 +25,7 @@ else:
     SECRET_KEY = '6n$fr-9vudyln(o=6jzv*pr_3b9(kajv=#&wq6ep4vm_s1m@6p'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.getenv('NAME').lower() != "production"
 
 ALLOWED_HOSTS = os.getenv('DJANGO_ALLOWED_HOSTS', '127.0.0.1').split(',')
 


### PR DESCRIPTION
## SETTING THE SCENE

### Chelsea, to Cam, on the fateful evening of April 14:

Hiya Cam! I am working on getting theia to authenticate, and when I go to theia.zooniverse.org and click on “Connect to Zooniverse”, I am seeing “The redirect URI is not valid.”

Now, we’ve debugged similar issues of this nature before. On the prior occasion, the issue was that I had omitted a trailing slash from a redirect uri in doorkeeper. In this case, though, it appears to be there: https://panoptes.zooniverse.org/oauth/applications/128/edit

I thought I’d check with you to see if you notice off the bat anything that I am missing, or maybe doing wrong?

If not, my hope is to get a peek at the production theia’s logs

### Cam replies with the critical clues!

So it looks like your redirect_url is using the HTTP protocol and not the HTTPS one (i.e. what’s the valid redirect on your oauth app)
This is what i pulled out of the network traffic
```
redirect_uri=http://theia.zooniverse.org/oauth/complete/panoptes/?redirect_state=8aEh0hOxgPl7E5ksfIniurmsAvrtiEBd&state=8aEh0hOxgPl7E5ksfIniurmsAvrtiEBd&response_type=code
```
from clicking ‘Connect to Zooniverse’
```
https://panoptes.zooniverse.org/oauth/authorize?client_id=93cc6245ea827c280b5ba066484f5d4bd41cfe992973a4c2e153a4b4c669d790&redirect_uri=http://theia.zooniverse.org/oauth/complete/panoptes/?redirect_state=8aEh0hOxgPl7E5ksfIniurmsAvrtiEBd&state=8aEh0hOxgPl7E5ksfIniurmsAvrtiEBd&response_type=code
```
I can’t see where that’s being setup in the app but TBH, perhaps but most likely not related to [this](https://github.com/zooniverse/theia/blob/9dd52f3540bdda0217815d1dc29f3f3a1c281a84/kubernetes/deployment-production.tmpl#L35-L36)

So - Solution is to make sure you use a secure protocol scheme for that redirect URL and it’ll match in panoptes oauth API.
See [SOCIAL_AUTH_REDIRECT_IS_HTTPS](https://python-social-auth.readthedocs.io/en/latest/configuration/settings.html)

```
 kubernetes/deployment-production.tmpl:35-36
          - name: DJANGO_ALLOWED_HOSTS
            value: theia.zooniverse.org
```

also - fwiw you should use the https://www.zoonivese.org URL instead of the https://panoptes.zooniverse.org URL to allow
 for single sign on with our main domain and theia app. By changing the auth URL it’ll re-use the cookie on the www.zooniverse.org domain instead of making folks sign in again on the other domain.
 
## THE PROBLEM

It turned out that we _were_ setting `SOCIAL_AUTH_REDIRECT_IS_HTTPS` in settings.py (line 171), but we were doing so on the condition that `DEBUG` was set to false, and further up in the code, we were hardcoding `DEBUG` to True always, with a comment that says "Do not set this to true in production! 

## THE FIX(ES)

So I changed it such that it will be set to False if the environment name is 'production', and True otherwise.

I also changed the URL from "panoptes.zooniverse.org" to "www.zooniverse.org" as Cam describes above!