### PR TITLE
rename name back to env

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -30,7 +30,7 @@ spec:
           env:
           - name: PANOPTES_URL
             value: https://panoptes.zooniverse.org/
-          - name: ENV
+          - name: DJANGO_ENV
             value: production
           - name: DJANGO_ALLOWED_HOSTS
             value: theia.zooniverse.org

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -27,7 +27,7 @@ spec:
           env:
             - name: PANOPTES_URL
               value: https://panoptes-staging.zooniverse.org/
-            - name: ENV
+            - name: DJANGO_ENV
               value: staging
             - name: PANOPTES_CLIENT_ID
               valueFrom:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -27,6 +27,8 @@ spec:
           env:
             - name: PANOPTES_URL
               value: https://panoptes-staging.zooniverse.org/
+            - name: ENV
+              value: staging
             - name: PANOPTES_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/theia/settings.py
+++ b/theia/settings.py
@@ -26,7 +26,7 @@ else:
 
 # SECURITY WARNING: don't run with debug turned on in production!
 
-DEBUG = os.getenv('ENV').lower() != "production"
+DEBUG = os.getenv('DJANGO_ENV').lower() != "production"
 
 ALLOWED_HOSTS = os.getenv('DJANGO_ALLOWED_HOSTS', '127.0.0.1').split(',')
 

--- a/theia/settings.py
+++ b/theia/settings.py
@@ -25,7 +25,8 @@ else:
     SECRET_KEY = '6n$fr-9vudyln(o=6jzv*pr_3b9(kajv=#&wq6ep4vm_s1m@6p'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+
+DEBUG = os.getenv('ENV').lower() != "production"
 
 ALLOWED_HOSTS = os.getenv('DJANGO_ALLOWED_HOSTS', '127.0.0.1').split(',')
 

--- a/theia/settings.py
+++ b/theia/settings.py
@@ -19,7 +19,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-if os.environ.get('ENV') == "production":
+if os.environ.get('DJANGO_ENV') == "production":
     SECRET_KEY = os.environ.get('SECRET_KEY')
 else:
     SECRET_KEY = '6n$fr-9vudyln(o=6jzv*pr_3b9(kajv=#&wq6ep4vm_s1m@6p'
@@ -88,7 +88,7 @@ WSGI_APPLICATION = 'theia.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
-if os.environ.get('ENV') == "production":
+if os.environ.get('DJANGO_ENV') == "production":
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',


### PR DESCRIPTION
Oy vey. I thought it was a great idea to rename 'ENV' to 'NAME' so that `os.getEnv('NAME')` would be prettier. This was a mistake. 

First of all, 'ENV' is in a number of places and I did not catch them all. Second of all, besides this _one line_, everywhere else where this is used, developers expect something containing 'ENV.'

We're switching to `DJANGO_ENV`, in fact, following the pattern in docker-compose.yml.