### PR TITLE
exempt call on an API app from csrf check because we're already authe…

### DIFF
--- a/theia/urls.py
+++ b/theia/urls.py
@@ -22,9 +22,10 @@ from theia.api import views
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib.auth import views as auth_views
+from django.views.decorators.csrf import csrf_exempt
 
 router = routers.DefaultRouter()
-router.register(r'imagery_requests', views.ImageryRequestViewSet)
+router.register(r'imagery_requests', csrf_exempt(views.ImageryRequestViewSet))
 router.register(r'job_bundles', views.JobBundleViewSet)
 router.register(r'pipelines', views.PipelineViewSet)
 router.register(r'pipeline_stages', views.PipelineStageViewSet)


### PR DESCRIPTION
## Django-REST enables CSRF checking by default

I didn't realize this before deployment because it doesn't check this in the development environment (whoops). I figured this out when trying to make an ImageryRequest for the first time on the deployed version and got 403 Forbidden.

The CSRF token is how Django-REST secures apps using SessionAuthentication. There are three options: SessionAuthentication, TokenAuthentication, and OAuth2.0. 

We're using OAuth2.0 to secure our app, but we're doing it through a dependency called `social-auth`, not through Django-REST's built in stuff. But we _have_ to choose one of the auth options in Django-REST even if we're handling our own auth, so SessionAuthentication was selected, and it doesn't realize we're doing our own auth.

This PR disables the csrf check for the ImageryRequest endpoint.