### PR TITLE
Add a port for redis to docker-compose in response to seeing redis connection issue in prod

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
   redis:
     image: redis:5.0.3-stretch
     command: redis-server --appendonly yes
+    ports:
+      - "6379:6379"
 
   app:
     build:


### PR DESCRIPTION
Pairing with @lcjohnso to figure out how to get redis hooked up for deployed theia.

@zwolf, does this look like the right change? We're suspicious because this is just the docker-compose, and `deployment-production.tmpl` _does_ have the redis port.