### PR TITLE
Point Celery at redis in production

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -34,6 +34,8 @@ spec:
             value: production
           - name: DJANGO_ALLOWED_HOSTS
             value: theia.zooniverse.org
+          - name: CELERY_REDIS_URL
+            value: 'redis://theia-production-redis:6379/0'
           volumeMounts:
             - name: theia-production-volume
               mountPath: "/tmp"

--- a/theia/celery.py
+++ b/theia/celery.py
@@ -10,7 +10,7 @@ libtiff_ctypes.suppress_warnings()
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'theia.settings')
 django.setup()
 
-app = Celery('theia', broker='redis://redis', backend='redis://redis')
+app = Celery('theia')
 
 # Using a string here means the worker doesn't have to serialize
 # the configuration object to child processes.

--- a/theia/settings.py
+++ b/theia/settings.py
@@ -162,6 +162,8 @@ REST_FRAMEWORK = {
 }
 
 CELERY_ENABLE_UTC = True
+CELERY_RESULT_BACKEND = os.environ.get('CELERY_REDIS_URL', 'redis://redis')
+CELERY_BROKER_URL = os.environ.get('CELERY_REDIS_URL', 'redis://redis')
 
 AUTHENTICATION_BACKENDS = (
     'theia.utils.panoptes_oauth2.PanoptesOAuth2',


### PR DESCRIPTION
Celery needs to know where redis is in production. This setup should work for version 4.3.0.