### PR TITLE
Put tmp dir in local app location

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -38,7 +38,7 @@ spec:
             value: 'redis://theia-production-redis:6379/0'
           volumeMounts:
             - name: theia-production-volume
-              mountPath: "/tmp"
+              mountPath: "/usr/src/app/tmp"
       volumes:
         - name: theia-production-volume
           persistentVolumeClaim:


### PR DESCRIPTION
Mount the PVC (azure storage) at /usr/src/app/tmp. This is the current app location as set by the WORKDIR directive in the Dockerfile. The rest of the app should use this folder for storage of interstitial files during processing. It won't be cleaned out automatically and has a 5GB limit, so it's the app's responsibility to make sure it doesn't fill up.