### PR TITLE
Set Host headers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       - ./:/usr/src/app
     environment:
-      - DJANGO_ENV
+      - DJANGO_ENV=development
       - USGS_USERNAME=something_secret_goes_here
       - USGS_PASSWORD=something_secret_goes_here
       - PANOPTES_PROD_CLIENT_ID
@@ -49,7 +49,7 @@ services:
     volumes:
       - ./:/usr/src/app
     environment:
-      - DJANGO_ENV
+      - DJANGO_ENV=development
       - USGS_USERNAME=something_secret_goes_here
       - USGS_PASSWORD=something_secret_goes_here
       - PANOPTES_PROD_CLIENT_ID

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -39,7 +39,7 @@ data:
 
       location / {
         proxy_pass http://docker-theia;
-        proxy_set_header Host $http_host;
+        proxy_set_header Host theia.zooniverse.org;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -118,6 +118,8 @@ spec:
               httpHeaders:
                  - name: X-Forwarded-Proto
                    value: https
+                 - name: Host
+                   value: theia.zooniverse.org
             initialDelaySeconds: 10
           readinessProbe:
             httpGet:
@@ -126,6 +128,8 @@ spec:
               httpHeaders:
                  - name: X-Forwarded-Proto
                    value: https
+                 - name: Host
+                   value: theia.zooniverse.org
             initialDelaySeconds: 10
           lifecycle:
             preStop:


### PR DESCRIPTION
Getting a lot of these now that nginx is in front:
```
[ff-import django.security.DisallowedHost] ERROR 2021-06-23 23:06:38,754 Invalid HTTP_HOST header: '[ip]:80'. You may need to add '[ip]' to ALLOWED_HOSTS.
[ff-import django.request] WARNING 2021-06-23 23:06:38,765 Bad Request: /
```

So this sets the proxy_pass_header Host straight to theia.zooniverse.org. Also updated the readiness/liveness probes to do the same.