### PR TITLE
Use alias instead of root for static assets

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -19,7 +19,7 @@ data:
       }
 
       location ~ ^/static/ {
-        root /static-assets/;
+        alias /static-assets/;
         gzip_static on; # to serve pre-gzipped version
         expires max;
         add_header Cache-Control public;


### PR DESCRIPTION
`root` appends the location (in this case, `/static/`) to the end. We just wanna alias the two.