### PR TITLE
CI: Run tests in Github Action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ WORKDIR /usr/src/app
 COPY Pipfile ./
 COPY Pipfile.lock ./
 COPY start_server.sh ./
-COPY start_worker.sh ./
 
 RUN pipenv install --system --dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ WORKDIR /usr/src/app
 COPY Pipfile ./
 COPY Pipfile.lock ./
 COPY start_server.sh ./
+COPY start_worker.sh ./
 
 RUN pipenv install --system --dev
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,6 @@ pipeline {
           def dockerImageName = "${dockerRepoName}:${GIT_COMMIT}"
           def newImage = docker.build(dockerImageName)
           newImage.push()
-          newImage.push('${GIT_COMMIT}')
 
           if (BRANCH_NAME == 'master') {
             stage('Update latest tag') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   postgres:
-    image: postgres:9.4
+    image: postgres:11
     volumes:
       - pgdata:/var/lib/postgresql/data
     environment:

--- a/run_tests.yml
+++ b/run_tests.yml
@@ -1,0 +1,16 @@
+name: Zooni CI
+on:
+  pull_request:
+  push: { branches: master }
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build images and create containers
+      run: docker compose up -d --build
+    - name: Run Tests
+      run: docker exec -it app pytest


### PR DESCRIPTION
Run tests in CI. This doesn't cache the docker layers and will redownload/rebuild each image every time, so if this works caching should be added. 

Also, this PR will not actually run the action because it needs to be seen on the main branch before GH will acknowledge it. Once this merges, new (and rebased) PRs will use this action.

Finally: this includes the removal of the Jenkinsfile line that now breaks pushing the image by Jenkins. This is in another open PR too but I didn't want to leave those checks failing.