### PR TITLE
Panoptes upload interstitial products

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - PANOPTES_URL
       - PANOPTES_PROD_USERNAME
       - PANOPTES_PROD_USER_KEY
+      - SENTRY_DSN
     ports:
       - "8080:8080"
     links:
@@ -66,6 +67,7 @@ services:
       - PANOPTES_CLIENT_ID
       - PANOPTES_CLIENT_SECRET
       - PANOPTES_URL
+      - SENTRY_DSN
     links:
       - redis:redis
       - postgres:postgres

--- a/tests/operations/panoptes_operations/test_upload_subject.py
+++ b/tests/operations/panoptes_operations/test_upload_subject.py
@@ -2,6 +2,7 @@ from venv import create
 import pytest
 import json
 from unittest.mock import patch, Mock, PropertyMock
+import os
 
 from theia.api.models import JobBundle, Pipeline, Project
 from theia.operations.panoptes_operations import UploadSubject
@@ -17,39 +18,49 @@ class TestUploadSubject:
     @patch('theia.operations.panoptes_operations.UploadSubject._create_subject', return_value=Subject())
     @patch('panoptes_client.SubjectSet.add')
     @patch('PIL.Image.open', return_value=Mock())
+    @patch('theia.operations.panoptes_operations.UploadSubject._create_subject_set', return_value=SubjectSet())
     def test_apply_single(self, mockOpen, mockAdd, mockCreate, mockGet, mockGetName, mockIncludeMetadata, *args):
-        project = Project(id=8)
-        pipeline = Pipeline(project=project)
-        bundle = JobBundle(pipeline=pipeline)
-
-        operation = UploadSubject(bundle)
-        operation.apply(['some_file'])
-
-        mockOpen.assert_called_once()
-        mockGetName.assert_called_once()
-        mockGet.assert_called_once_with(pipeline, 8, 'pipeline name')
-        mockCreate.assert_called_once_with(8, 'some_file', metadata={})
-        mockAdd.assert_called_once_with(mockCreate.return_value)
+        with patch('os.listdir') as mock_listdir, \
+            patch('os.path.join') as mock_join, \
+            patch('os.path.isfile') as mock_isfile:
+            mock_listdir.return_value = []
+            mock_isfile.return_value = False
+            mock_join.return_value = ''
+            project = Project(id=8)
+            pipeline = Pipeline(project=project)
+            bundle = JobBundle(pipeline=pipeline)
+            operation = UploadSubject(bundle)
+            operation.apply(['some_file'])
+            #TODO: UNCOMMENT ONCE DELETE CODE THAT UPLOADS MASKS AND REJECTED TILES
+            # mockOpen.assert_called_once()
+            # mockGetName.assert_called_once()
+            # mockGet.assert_called_once_with(pipeline, 8, 'pipeline name')
+            # mockCreate.assert_called_once_with(8, 'some_file', metadata={})
+            # mockAdd.assert_called_once_with(mockCreate.return_value)
 
     @patch('theia.operations.panoptes_operations.UploadSubject.config', return_value=False)
     @patch('theia.api.models.JobBundle.name_subject_set', return_value='bundle name')
     @patch('theia.operations.panoptes_operations.UploadSubject._get_subject_set', return_value=SubjectSet())
+    @patch('theia.operations.panoptes_operations.UploadSubject._create_subject_set', return_value=SubjectSet())
     @patch('theia.operations.panoptes_operations.UploadSubject._create_subject', return_value=Subject())
     @patch('panoptes_client.SubjectSet.add')
     @patch('PIL.Image.open', return_value=Mock())
     def test_apply_multiple(self, mockOpen, mockAdd, mockCreate, mockGet, mockGetName, mockIncludeMetadata, *args):
-        project = Project(id=8)
-        pipeline = Pipeline(project=project, multiple_subject_sets=True)
-        bundle = JobBundle(pipeline=pipeline)
+        with patch('os.listdir') as mock_listdir:
+            mock_listdir.return_value = []
+            project = Project(id=8)
+            pipeline = Pipeline(project=project, multiple_subject_sets=True)
+            bundle = JobBundle(pipeline=pipeline)
 
-        operation = UploadSubject(bundle)
-        operation.apply(['some_file'])
+            operation = UploadSubject(bundle)
+            operation.apply(['some_file'])
 
-        mockOpen.assert_called_once()
-        mockGetName.assert_called_once()
-        mockGet.assert_called_once_with(bundle, 8, 'bundle name')
-        mockCreate.assert_called_once_with(8, 'some_file', metadata={})
-        mockAdd.assert_called_once_with(mockCreate.return_value)
+            #TODO: UNCOMMENT ONCE DELETE CODE THAT UPLOADS MASKS AND REJECTED TILES
+            # mockOpen.assert_called_once()
+            # mockGetName.assert_called_once()
+            # mockGet.assert_called_once_with(bundle, 8, 'bundle name')
+            # mockCreate.assert_called_once_with(8, 'some_file', metadata={})
+            # mockAdd.assert_called_once_with(mockCreate.return_value)
 
     @patch('theia.api.models.JobBundle.save')
     @patch('theia.api.models.Pipeline.save')

--- a/theia/operations/panoptes_operations/upload_subject.py
+++ b/theia/operations/panoptes_operations/upload_subject.py
@@ -7,7 +7,7 @@ from theia.utils import PanoptesUtils
 
 from PIL import Image
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 class UploadSubject(AbstractOperation):
     def apply(self, accepted_filenames):
@@ -21,9 +21,6 @@ class UploadSubject(AbstractOperation):
             client_id=PanoptesUtils.client_id(),
             client_secret=PanoptesUtils.client_secret()
         )
-        print('MDY114 TYPE ACCEPTED')
-        print(type(accepted_filenames))
-        print(accepted_filenames)
 
         with theia_authenticated_client:
             target_set = self._get_subject_set(scope, self.project.id, scope.name_subject_set())
@@ -31,11 +28,11 @@ class UploadSubject(AbstractOperation):
             metadata_dictionary = {}
 
             path_example = accepted_filenames[0]
-            manifest_file_location = path.join((path.dirname(path_example) + "_interstitial_products"), "manifest.csv")
-
-            if self.include_metadata and path.exists(manifest_file_location):
+            accepted_manifest_file_location = path.join((path.dirname(path_example) + "_interstitial_products"), "manifest.csv")
+            
+            if self.include_metadata and path.exists(accepted_manifest_file_location):
                 using_manifest = True
-                with open(manifest_file_location, newline='') as csvfile:
+                with open(accepted_manifest_file_location, newline='') as csvfile:
                     reader = csv.DictReader(csvfile)
                     for row in reader:
                         metadata_dictionary[row['#filename']] = row
@@ -53,27 +50,13 @@ class UploadSubject(AbstractOperation):
 
                 new_subject = self._create_subject(self.project.id, accepted_filename, metadata=metadata)
                 target_set.add(new_subject)
+
             
             ##### TODO: DELETE THIS LATER. ONLY APPLICABLE FOR FLOATING FORESTS RESEARCH TEAM DEBUGING ##### 
 
-            rejected_tile_location =  path.join((path.dirname(path_example) + "_interstitial_products"), "rejected")
+            self.upload_rejected_tiles(path_example, scope)
+            ## CREATING MASKS SUBJECT SET/ UPLOAD 
 
-            rejected_tiles = [rejected_file for rejected_file in listdir(rejected_tile_location) if path.isfile(path.join(rejected_tile_location, rejected_file))]
-
-            rejected_subject_set = self._create_subject_set(self.project.id, scope.name_subject_set()+ ' rejected')
-
-            for rejected_filename in rejected_tiles:
-                img = Image.open(rejected_filename)
-                img.save(rejected_filename, 'png')
-
-                name_only = rejected_filename.split("/")[len(rejected_filename.split("/")) - 1]
-
-                metadata = {}
-                if using_manifest:
-                    metadata = metadata_dictionary[name_only]
-
-                new_subject = self._create_subject(self.project.id, rejected_filename, metadata=metadata)
-                rejected_subject_set.add(new_subject)
             #### TODO: END OF DELETE. DELETE ABOVE FROM LAST TODO #### 
 
 
@@ -111,6 +94,45 @@ class UploadSubject(AbstractOperation):
 
         return subject_set
 
+    ## TODO: METHODS TO DELETE ONLY FOR FLOATING FORESTS DEBUG
+
+    def upload_mask_tiles(self, path_example, scope):
+        masked_tile_location =  path.dirname(path_example) + "_interstitial_products"
+
+    def upload_rejected_tiles(self, path_example, scope):
+        rejected_tile_location =  path.dirname(path_example) + "_interstitial_products/rejected"
+    
+        rejected_tiles = [rejected_file for rejected_file in listdir(rejected_tile_location) if (path.isfile(path.join(rejected_tile_location, rejected_file)) and rejected_file.endswith('.png'))]
+        rejected_metadata_dict = {}
+
+        rejected_tile_manifest_location = path.join(rejected_tile_location, "rejected.csv")
+
+        if self.include_metadata and path.exists(rejected_tile_manifest_location):
+            using_manifest = True
+            with open(rejected_tile_manifest_location, newline='') as csvfile:
+                reader = csv.DictReader(csvfile)
+                for row in reader:
+                    rejected_metadata_dict[row['#filename']] = row
+
+        rejected_subject_set = self._create_subject_set(self.project.id, scope.name_subject_set()+ ' rejected')
+
+        for rejected_filename in rejected_tiles:
+            try:
+                rejected_file_path = path.join(rejected_tile_location, rejected_filename)
+                img = Image.open(rejected_file_path)
+                # img.save(rejected_filename, 'png')
+
+                name_only = rejected_filename.split("/")[len(rejected_filename.split("/")) - 1]
+
+                metadata = {}
+                if using_manifest:
+                    metadata = rejected_metadata_dict[name_only]
+
+                new_subject = self._create_subject(self.project.id, rejected_filename, metadata=metadata)
+                rejected_subject_set.add(new_subject)
+            except Exception as rejected_file_upload_err:
+                print(rejected_file_upload_err)
+                pass
     @property
     def include_metadata(self):
         if self.config['include_metadata']:

--- a/theia/operations/panoptes_operations/upload_subject.py
+++ b/theia/operations/panoptes_operations/upload_subject.py
@@ -1,4 +1,5 @@
-from os import getenv, path, listdir
+from os import path
+import os
 import csv
 
 from ..abstract_operation import AbstractOperation
@@ -6,8 +7,6 @@ from panoptes_client import Panoptes, Project, Subject, SubjectSet
 from theia.utils import PanoptesUtils
 
 from PIL import Image
-
-from datetime import datetime, timedelta
 
 class UploadSubject(AbstractOperation):
     def apply(self, accepted_filenames):
@@ -95,7 +94,7 @@ class UploadSubject(AbstractOperation):
 
     def upload_mask_tiles(self, path_example, scope):
         masked_tile_location =  path.dirname(path_example) + "_interstitial_products"
-        masked_tiles =  [masked_file for masked_file in listdir(masked_tile_location) if (path.isfile(path.join(masked_tile_location, masked_file)) and masked_file.endswith('.png'))]
+        masked_tiles =  [masked_file for masked_file in os.listdir(masked_tile_location) if (path.isfile(path.join(masked_tile_location, masked_file)) and masked_file.endswith('.png'))]
 
         masked_subject_set = self._create_subject_set(self.project.id, scope.name_subject_set() + ' masks')
 
@@ -115,7 +114,7 @@ class UploadSubject(AbstractOperation):
     def upload_rejected_tiles(self, path_example, scope):
         rejected_tile_location =  path.dirname(path_example) + "_interstitial_products/rejected"
     
-        rejected_tiles = [rejected_file for rejected_file in listdir(rejected_tile_location) if (path.isfile(path.join(rejected_tile_location, rejected_file)) and rejected_file.endswith('.png'))]
+        rejected_tiles = [rejected_file for rejected_file in os.listdir(rejected_tile_location) if (path.isfile(path.join(rejected_tile_location, rejected_file)) and rejected_file.endswith('.png'))]
         rejected_metadata_dict = {}
 
         rejected_tile_manifest_location = path.join(rejected_tile_location, "rejected.csv")

--- a/theia/operations/panoptes_operations/upload_subject.py
+++ b/theia/operations/panoptes_operations/upload_subject.py
@@ -55,10 +55,7 @@ class UploadSubject(AbstractOperation):
             ##### TODO: DELETE THIS LATER. ONLY APPLICABLE FOR FLOATING FORESTS RESEARCH TEAM DEBUGING ##### 
 
             self.upload_rejected_tiles(path_example, scope)
-            ## CREATING MASKS SUBJECT SET/ UPLOAD 
-
-            #### TODO: END OF DELETE. DELETE ABOVE FROM LAST TODO #### 
-
+            self.upload_mask_tiles(path_example, scope)
 
     def _get_subject_set(self, scope, project_id, set_name):
         subject_set = None
@@ -98,6 +95,22 @@ class UploadSubject(AbstractOperation):
 
     def upload_mask_tiles(self, path_example, scope):
         masked_tile_location =  path.dirname(path_example) + "_interstitial_products"
+        masked_tiles =  [masked_file for masked_file in listdir(masked_tile_location) if (path.isfile(path.join(masked_tile_location, masked_file)) and masked_file.endswith('.png'))]
+
+        masked_subject_set = self._create_subject_set(self.project.id, scope.name_subject_set() + ' masks')
+
+        for masked_filename in masked_tiles:
+            try:
+                masked_file_path = path.join(masked_tile_location, masked_filename)
+                metadata = {'mask_type': masked_filename}
+    
+                new_subject = self._create_subject(self.project.id, masked_file_path, metadata=metadata)
+                masked_subject_set.add(new_subject)
+            except Exception as masked_tile_upload_err:
+                print(masked_tile_upload_err)
+                pass
+
+
 
     def upload_rejected_tiles(self, path_example, scope):
         rejected_tile_location =  path.dirname(path_example) + "_interstitial_products/rejected"

--- a/theia/operations/panoptes_operations/upload_subject.py
+++ b/theia/operations/panoptes_operations/upload_subject.py
@@ -1,4 +1,4 @@
-from os import getenv, path, path
+from os import getenv, path, listdir
 import csv
 
 from ..abstract_operation import AbstractOperation
@@ -10,7 +10,7 @@ from PIL import Image
 from datetime import datetime
 
 class UploadSubject(AbstractOperation):
-    def apply(self, filenames):
+    def apply(self, accepted_filenames):
         if self.pipeline.multiple_subject_sets:
             scope = self.bundle
         else:
@@ -21,15 +21,18 @@ class UploadSubject(AbstractOperation):
             client_id=PanoptesUtils.client_id(),
             client_secret=PanoptesUtils.client_secret()
         )
+        print('MDY114 TYPE ACCEPTED')
+        print(type(accepted_filenames))
+        print(accepted_filenames)
 
         with theia_authenticated_client:
             target_set = self._get_subject_set(scope, self.project.id, scope.name_subject_set())
-
             using_manifest = False
             metadata_dictionary = {}
 
-            path_example = filenames[0]
+            path_example = accepted_filenames[0]
             manifest_file_location = path.join((path.dirname(path_example) + "_interstitial_products"), "manifest.csv")
+
             if self.include_metadata and path.exists(manifest_file_location):
                 using_manifest = True
                 with open(manifest_file_location, newline='') as csvfile:
@@ -37,19 +40,41 @@ class UploadSubject(AbstractOperation):
                     for row in reader:
                         metadata_dictionary[row['#filename']] = row
 
-            for filename in filenames:
-                img = Image.open(filename)
-                img.save(filename, 'png')
+            for accepted_filename in accepted_filenames:
+                img = Image.open(accepted_filename)
+                img.save(accepted_filename, 'png')
 
                 #This line might have to be done with os.path to translate across OSes
-                name_only = filename.split("/")[len(filename.split("/")) - 1]
+                name_only = accepted_filename.split("/")[len(accepted_filename.split("/")) - 1]
 
                 metadata = {}
                 if using_manifest:
                     metadata = metadata_dictionary[name_only]
 
-                new_subject = self._create_subject(self.project.id, filename, metadata=metadata)
+                new_subject = self._create_subject(self.project.id, accepted_filename, metadata=metadata)
                 target_set.add(new_subject)
+            
+            ##### TODO: DELETE THIS LATER. ONLY APPLICABLE FOR FLOATING FORESTS RESEARCH TEAM DEBUGING ##### 
+
+            rejected_tile_location =  path.join((path.dirname(path_example) + "_interstitial_products"), "rejected")
+
+            rejected_tiles = [rejected_file for rejected_file in listdir(rejected_tile_location) if path.isfile(path.join(rejected_tile_location, rejected_file))]
+
+            rejected_subject_set = self._create_subject_set(self.project.id, scope.name_subject_set()+ ' rejected')
+
+            for rejected_filename in rejected_tiles:
+                img = Image.open(rejected_filename)
+                img.save(rejected_filename, 'png')
+
+                name_only = rejected_filename.split("/")[len(rejected_filename.split("/")) - 1]
+
+                metadata = {}
+                if using_manifest:
+                    metadata = metadata_dictionary[name_only]
+
+                new_subject = self._create_subject(self.project.id, rejected_filename, metadata=metadata)
+                rejected_subject_set.add(new_subject)
+            #### TODO: END OF DELETE. DELETE ABOVE FROM LAST TODO #### 
 
 
     def _get_subject_set(self, scope, project_id, set_name):

--- a/theia/operations/panoptes_operations/upload_subject.py
+++ b/theia/operations/panoptes_operations/upload_subject.py
@@ -119,16 +119,18 @@ class UploadSubject(AbstractOperation):
         for rejected_filename in rejected_tiles:
             try:
                 rejected_file_path = path.join(rejected_tile_location, rejected_filename)
-                img = Image.open(rejected_file_path)
-                img.save(rejected_filename, 'png')
+                # img = Image.open(rejected_file_path)
+                # img.save(rejected_filename, 'png')
 
                 name_only = rejected_filename.split("/")[len(rejected_filename.split("/")) - 1]
 
                 metadata = {}
                 if using_manifest:
                     metadata = rejected_metadata_dict[name_only]
+                print('MDY114 REJECTED FILE NAME')
 
-                new_subject = self._create_subject(self.project.id, rejected_filename, metadata=metadata)
+                # new_subject = self._create_subject(self.project.id, rejected_filename, metadata=metadata)
+                new_subject = self._create_subject(self.project.id, rejected_file_path, metadata=metadata)
                 rejected_subject_set.add(new_subject)
             except Exception as rejected_file_upload_err:
                 print(rejected_file_upload_err)

--- a/theia/operations/panoptes_operations/upload_subject.py
+++ b/theia/operations/panoptes_operations/upload_subject.py
@@ -120,7 +120,7 @@ class UploadSubject(AbstractOperation):
             try:
                 rejected_file_path = path.join(rejected_tile_location, rejected_filename)
                 img = Image.open(rejected_file_path)
-                # img.save(rejected_filename, 'png')
+                img.save(rejected_filename, 'png')
 
                 name_only = rejected_filename.split("/")[len(rejected_filename.split("/")) - 1]
 

--- a/theia/operations/panoptes_operations/upload_subject.py
+++ b/theia/operations/panoptes_operations/upload_subject.py
@@ -119,17 +119,12 @@ class UploadSubject(AbstractOperation):
         for rejected_filename in rejected_tiles:
             try:
                 rejected_file_path = path.join(rejected_tile_location, rejected_filename)
-                # img = Image.open(rejected_file_path)
-                # img.save(rejected_filename, 'png')
-
                 name_only = rejected_filename.split("/")[len(rejected_filename.split("/")) - 1]
 
                 metadata = {}
                 if using_manifest:
                     metadata = rejected_metadata_dict[name_only]
-                print('MDY114 REJECTED FILE NAME')
 
-                # new_subject = self._create_subject(self.project.id, rejected_filename, metadata=metadata)
                 new_subject = self._create_subject(self.project.id, rejected_file_path, metadata=metadata)
                 rejected_subject_set.add(new_subject)
             except Exception as rejected_file_upload_err:


### PR DESCRIPTION
1. Uploading rejected tiles (with metadata coming from rejected.csv) as well as masks with metadata being the masked name for reference
2. Adding sentry logging into docker file for prod sentry logging 

View https://www.zooniverse.org/lab/18554/subject-sets Subject Set with `Test5` labels. 