### PR TITLE
Capture usgs connection errors 

### DIFF
--- a/theia/adapters/usgs/eros_wrapper.py
+++ b/theia/adapters/usgs/eros_wrapper.py
@@ -2,6 +2,7 @@ from .utils import Utils
 import json
 import requests
 import sys
+from sentry_sdk import capture_message
 
 class ErosWrapper():
 
@@ -58,6 +59,3 @@ class ErosWrapper():
         response.close()
 
         return output['data']
-
-
-

--- a/theia/adapters/usgs/eros_wrapper.py
+++ b/theia/adapters/usgs/eros_wrapper.py
@@ -42,6 +42,7 @@ class ErosWrapper():
             output = json.loads(response.text)
             if output['errorCode'] != None:
                 print(output['errorCode'], "- ", output['errorMessage'])
+                capture_message('USGS Connection Error - ' + output['errorCode'] + ' - ' + output['errorMessage'])
                 sys.exit()
             if httpStatusCode == 404:
                 print("404 Not Found")


### PR DESCRIPTION
usgs api connection has been finicky in the past, in a prod setting, hard to catch when connection to landsat data api fails, adding a capture message when usgs returns errors