### PR TITLE
Update jenkinsfile only slack when deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
           slackSend (
             color: '#00FF00',
             message: "SUCCESSFUL: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})",
-            channel: "#ops"
+            channel: "#deploys"
           )
         }
       }
@@ -64,7 +64,7 @@ pipeline {
           slackSend (
             color: '#FF0000',
             message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})",
-            channel: "#ops"
+            channel: "#deploys"
           )
         }
       }


### PR DESCRIPTION
This is more cleanup/to avoid confusion. This change will only have jenkins job send a message only if we are actually deploying to production. (Also send this to deploys channel as opposed to ops channel). 

As a recap, a merge to master will run jenkins job but will skip a deploy (typically we have this set up to deploy to staging), but I believe it was requested to not have a staging deploy/environment. 

therefore, the jenkins job triggered from a merge to master will build the docker image and then send out slack message of success (or failure if the docker image fails to build, but that would have easily been caught in the PR GH actions anyway). 