### PR TITLE
update dockerfile, ensure numpy is installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ RUN export GDAL_VERSION=$(gdal-config --version) \
   && pip install --global-option=build_ext --global-option="-I/usr/include/gdal/" \
     gdal~=${GDAL_VERSION}
 
+# ensure numpy installation for libtiff install
+RUN pip install numpy
+
 RUN pipenv install --system --dev
 
 COPY . /usr/src/app


### PR DESCRIPTION
ensure numpy is installed for libtiff package per errors: × python setup.py egg_info did not run successfully.
#15 9.137 [pipenv.exceptions.InstallError]:   │ exit code: 1
#15 9.137 [pipenv.exceptions.InstallError]:   ╰─> [6 lines of output]
#15 9.137 [pipenv.exceptions.InstallError]:       Traceback (most recent call last):
#15 9.137 [pipenv.exceptions.InstallError]:         File "<string>", line 36, in <module>
#15 9.137 [pipenv.exceptions.InstallError]:         File "<pip-setuptools-caller>", line 34, in <module>
#15 9.137 [pipenv.exceptions.InstallError]:         File "/tmp/pip-install-k048us7u/libtiff_5d9648a7d30d4df092ba425aadeb40c9/setup.py", line 77, in <module>
#15 9.138 [pipenv.exceptions.InstallError]:           from numpy.distutils.core import setup, Extension
#15 9.138 [pipenv.exceptions.InstallError]:       ModuleNotFoundError: No module named 'numpy'